### PR TITLE
Add App Store-style home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # FlutNFeel
 A simple yet powerful Flutter example project showcasing clean architecture, modular code structure, and integration with popular packages. This repository is designed to help developers quickly understand and implement common Flutter features in a maintainable way.
+
+## Features
+
+- App Store-style homepage displaying featured items using a scrollable list of cards.
+- Responsive layout that adapts to mobile, tablet, and web screens.
+
+## Running
+
+Ensure you have the Flutter SDK installed, then run:
+
+```
+flutter run
+```
+
+This will launch the example app on your chosen device or emulator. The project
+supports iOS, iPadOS, Android, and web targets; select your desired platform
+with `-d` followed by the device id (for example `-d chrome` for web).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'FlutNFeel Store',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  final List<AppStoreItem> items = const [
+    AppStoreItem(
+      title: 'Notes Pro',
+      category: 'Productivity',
+      imageUrl: 'https://picsum.photos/600/300?1',
+    ),
+    AppStoreItem(
+      title: 'Fitness Plus',
+      category: 'Health & Fitness',
+      imageUrl: 'https://picsum.photos/600/300?2',
+    ),
+    AppStoreItem(
+      title: 'Travel Buddy',
+      category: 'Travel',
+      imageUrl: 'https://picsum.photos/600/300?3',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Today')),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isWide = constraints.maxWidth >= 600;
+          if (isWide) {
+            return GridView.builder(
+              padding: const EdgeInsets.all(16),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                mainAxisSpacing: 24,
+                crossAxisSpacing: 24,
+                childAspectRatio: 0.75,
+              ),
+              itemCount: items.length,
+              itemBuilder: (context, index) {
+                final item = items[index];
+                return AppStoreCard(item: item);
+              },
+            );
+          }
+          return ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 24),
+                child: AppStoreCard(item: item),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class AppStoreItem {
+  final String title;
+  final String category;
+  final String imageUrl;
+
+  const AppStoreItem({
+    required this.title,
+    required this.category,
+    required this.imageUrl,
+  });
+}
+
+class AppStoreCard extends StatelessWidget {
+  final AppStoreItem item;
+
+  const AppStoreCard({super.key, required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(20),
+          child: Image.network(
+            item.imageUrl,
+            height: 200,
+            width: double.infinity,
+            fit: BoxFit.cover,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          item.category.toUpperCase(),
+          style: Theme.of(context).textTheme.labelSmall,
+        ),
+        Text(
+          item.title,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,17 @@
+name: flutnfeel
+description: A simple Flutter app demonstrating an App Store-style homepage.
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- implement responsive grid layout for wide screens
- document support for iOS, iPadOS, Android, and web targets

## Testing
- `dart format lib pubspec.yaml` *(fails: command not found: dart)*
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689dde9830508323be8769e489a8268a