### PR TITLE
feat(cocoapods): export Flutter module as a CocoaPods pod

### DIFF
--- a/EXPORT_COCOAPODS.md
+++ b/EXPORT_COCOAPODS.md
@@ -1,0 +1,96 @@
+# Export FlutNFeel as a CocoaPods Pod (Step by Step)
+
+This guide shows how to ship this Flutter module so iOS apps can consume it via CocoaPods ("ship Flutter as a pod").
+
+## Prerequisites
+
+- macOS with Xcode 15+
+- Flutter SDK (stable) installed
+- CocoaPods installed (via `gem install cocoapods` or Bundler)
+
+Optional (recommended for iOS folder work):
+- Ruby Bundler: `gem install bundler`
+
+## 1) Build iOS frameworks + Flutter engine podspec
+
+From the repo root:
+
+```bash
+flutter pub get
+flutter build ios-framework --output=./build/ios-framework --cocoapods --no-debug --no-profile
+```
+
+This generates:
+- `build/ios-framework/Release/App.xcframework` (compiled Dart + assets)
+- `build/ios-framework/Release/*.xcframework` (plugins)
+- `build/ios-framework/Release/Flutter.podspec` (engine pod)
+- `build/ios-framework/GeneratedPluginRegistrant.{h,m}`
+
+Shortcut script:
+
+```bash
+./scripts/build_pod.sh release
+```
+
+## 2) Choose a distribution strategy
+
+You have three common options:
+- Local development: consume via `:path => '/absolute/or/relative/path/to/FlutNFeel'`.
+- Git tag: create a tag (e.g., `0.1.0`) and consume via `:git` + `:tag`.
+- Binary release: host frameworks externally and update the podspec to point there (advanced).
+
+Note: If using git tags, ensure artifacts are available in the repo or adjust the podspec/source to a binary host.
+
+
+
+## 5) Versioning and tagging (if using git distribution)
+
+- Update `s.version` in `FlutNFeel.podspec` (e.g., `0.1.1`).
+- Commit and tag the repo:
+
+```bash
+git add .
+git commit -m "Bump to 0.1.1 and rebuild iOS frameworks"
+git tag 0.1.1
+git push origin develop --tags
+```
+
+- Update host app’s Podfile to the new `:tag` and run `pod install`.
+
+## 6) Rebuilding when Dart code or deps change
+
+Rebuild frameworks and engine podspec:
+
+```bash
+./scripts/build_pod.sh release
+```
+
+Commit artifacts (if your strategy needs them) and bump the pod version/tag.
+
+## 7) Debugging & notes
+
+- Apple Silicon simulator issues (arm64): some plugins may not support arm64 on the simulator. Workarounds:
+  - Exclude arm64 for simulator in the host app build settings, or
+  - Test on an actual device, or
+  - Ensure plugins include arm64 simulator slices.
+
+- LLDB & attach: If you plan to `flutter attach` for add-to-app debugging, follow Flutter docs to set your scheme’s LLDB init file for Debug builds.
+
+- If CocoaPods can’t find Flutter engine: confirm the `Flutter.podspec` path in the Podfile is correct and built.
+
+- Clean state: `rm -rf ~/Library/Developer/Xcode/DerivedData/*` if Xcode caches cause issues.
+
+- Clean CocoaPods state if needed:
+
+```bash
+cd ios
+pod deintegrate
+pod install
+```
+
+## 8) What this pod ships
+
+- `FlutNFeel.podspec`: vends `build/ios-framework/Release/*.xcframework` (App + plugins) and exports `GeneratedPluginRegistrant.h/m`.
+- Depends on the `Flutter` pod (engine) via the generated `Flutter.podspec` you point to in the host Podfile.
+
+That’s it — your iOS app can now present Flutter screens using this pod.

--- a/FlutNFeel.podspec
+++ b/FlutNFeel.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name             = 'FlutNFeel'
+  s.version          = '0.1.0'
+  s.summary          = 'FlutNFeel Flutter module for embedding in iOS apps.'
+  s.description      = <<-DESC
+FlutNFeel is a Flutter UI module packaged for iOS via CocoaPods.
+It vends the compiled Flutter App.xcframework and plugin xcframeworks, and includes
+GeneratedPluginRegistrant to wire up plugins. The Flutter engine itself is pulled in via
+the generated Flutter.podspec (see integration steps in README/COCOAPODS.md).
+  DESC
+  s.homepage         = 'https://github.com/motojojoe/FlutNFeel'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'FlutNFeel Authors' => 'noreply@example.com' }
+  s.platform         = :ios, '13.0'
+
+  # If you publish this pod, point to your git repo & tag. When using :path in a Podfile, CocoaPods ignores this.
+  s.source           = { :git => 'https://github.com/motojojoe/FlutNFeel.git', :tag => s.version.to_s }
+
+  # Compiled frameworks built with: `flutter build ios-framework --cocoapods --no-debug --no-profile`.
+  s.vendored_frameworks = 'build/ios-framework/Release/*.xcframework'
+
+  # Include GeneratedPluginRegistrant so consumers don't need to copy it into their app target.
+  s.source_files = 'build/ios-framework/GeneratedPluginRegistrant.{h,m}'
+  s.public_header_files = 'build/ios-framework/GeneratedPluginRegistrant.h'
+
+  # Depend on the Flutter engine pod; the consumer Podfile must point CocoaPods to the generated Flutter.podspec.
+  s.dependency 'Flutter'
+
+  # CocoaPods will handle embedding/signing of dynamic frameworks.
+  s.requires_arc = true
+end

--- a/FlutNFeel.podspec
+++ b/FlutNFeel.podspec
@@ -17,7 +17,7 @@ the generated Flutter.podspec (see integration steps in README/COCOAPODS.md).
   s.source           = { :git => 'https://github.com/motojojoe/FlutNFeel.git', :tag => s.version.to_s }
 
   # Compiled frameworks built with: `flutter build ios-framework --cocoapods --no-debug --no-profile`.
-  s.vendored_frameworks = 'build/ios-framework/Release/*.xcframework'
+  s.vendored_frameworks = 'build/ios-framework/Release/*.xcframework', 'build/ios-framework/Profile/*.xcframework', 'build/ios-framework/Debug/*.xcframework'
 
   # Include GeneratedPluginRegistrant so consumers don't need to copy it into their app target.
   s.source_files = 'build/ios-framework/GeneratedPluginRegistrant.{h,m}'

--- a/FlutNFeel.podspec
+++ b/FlutNFeel.podspec
@@ -17,7 +17,7 @@ the generated Flutter.podspec (see integration steps in README/COCOAPODS.md).
   s.source           = { :git => 'https://github.com/motojojoe/FlutNFeel.git', :tag => s.version.to_s }
 
   # Compiled frameworks built with: `flutter build ios-framework --cocoapods --no-debug --no-profile`.
-  s.vendored_frameworks = 'build/ios-framework/Release/*.xcframework', 'build/ios-framework/Profile/*.xcframework', 'build/ios-framework/Debug/*.xcframework'
+  s.vendored_frameworks = 'build/ios-framework/Release/*.xcframework'
 
   # Include GeneratedPluginRegistrant so consumers don't need to copy it into their app target.
   s.source_files = 'build/ios-framework/GeneratedPluginRegistrant.{h,m}'

--- a/README.md
+++ b/README.md
@@ -71,3 +71,94 @@ flutter run
 This will launch the example app on your chosen device or emulator. The project
 supports iOS, iPadOS, Android, and web targets; select your desired platform
 with `-d` followed by the device id (for example `-d chrome` for web).
+
+## Add to the host app Podfile
+If you want to embed this Flutter module in a native iOS app via CocoaPods
+In the iOS app’s `Podfile`:
+
+```ruby
+platform :ios, '13.0'
+use_frameworks!
+
+# Point to the generated Flutter engine podspec produced in Step 1.
+pod 'Flutter', :podspec => File.join(__dir__, '..', 'FlutNFeel', 'build', 'ios-framework', 'Release', 'Flutter.podspec')
+
+# Add the module pod:
+# Option A: Local path
+# pod 'FlutNFeel', :path => File.join(__dir__, '..', 'FlutNFeel')
+
+# Option B: Git tag
+# pod 'FlutNFeel', :git => 'https://github.com/motojojoe/FlutNFeel.git', :tag => '0.1.0'
+```
+
+Then install pods:
+
+```bash
+cd ios
+pod install
+```
+
+Open `YourApp.xcworkspace` and build.
+
+## Initialize Flutter in your app
+
+Minimal Swift example using a shared engine:
+
+```swift
+import UIKit
+import Flutter
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  lazy var flutterEngine = FlutterEngine(name: "flutnfeel_engine")
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    flutterEngine.run()
+    GeneratedPluginRegistrant.register(with: flutterEngine) // provided by FlutNFeel pod
+
+    window = UIWindow(frame: UIScreen.main.bounds)
+    window?.rootViewController = UINavigationController(rootViewController: ViewController())
+    window?.makeKeyAndVisible()
+    return true
+  }
+}
+
+class ViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+
+    let button = UIButton(type: .system)
+    button.setTitle("Show Flutter", for: .normal)
+    button.addTarget(self, action: #selector(showFlutter), for: .touchUpInside)
+    button.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(button)
+    NSLayoutConstraint.activate([
+      button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      button.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+    ])
+  }
+
+  @objc func showFlutter() {
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+    let flutterVC = FlutterViewController(engine: appDelegate.flutterEngine, nibName: nil, bundle: nil)
+    flutterVC.modalPresentationStyle = .fullScreen
+    present(flutterVC, animated: true)
+  }
+}
+```
+
+`App.xcframework` already contains `flutter_assets`. No extra copy steps are needed.
+
+## How to export as a CocoaPods
+
+To package and ship this Flutter module for iOS consumption via CocoaPods ("ship Flutter as a pod"), follow the step-by-step guide here:
+
+- See: [EXPORT_COCOAPODS.md](EXPORT_COCOAPODS.md)
+
+That guide covers:
+- Building iOS .xcframeworks and generating the Flutter engine podspec.
+- Choosing a distribution strategy (local path vs. git tag vs. binary).
+- Wiring your host app’s Podfile and initializing Flutter (engine + view controller).
+- Rebuilding on changes and common troubleshooting tips.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Open `YourApp.xcworkspace` and build.
 
 ## Initialize Flutter in your app
 
-Minimal Swift example using a shared engine:
+### UIKit Implementation
+
+Minimal UIKit example using a shared engine:
 
 ```swift
 import UIKit
@@ -128,12 +130,15 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .systemBackground
+    title = "FlutNFeel Demo"
 
     let button = UIButton(type: .system)
     button.setTitle("Show Flutter", for: .normal)
+    button.titleLabel?.font = UIFont.systemFont(ofSize: 18, weight: .medium)
     button.addTarget(self, action: #selector(showFlutter), for: .touchUpInside)
     button.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(button)
+    
     NSLayoutConstraint.activate([
       button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
       button.centerYAnchor.constraint(equalTo: view.centerYAnchor)
@@ -146,6 +151,86 @@ class ViewController: UIViewController {
     flutterVC.modalPresentationStyle = .fullScreen
     present(flutterVC, animated: true)
   }
+}
+```
+
+### SwiftUI Implementation
+
+For SwiftUI apps, you can integrate Flutter using a `UIViewControllerRepresentable`:
+
+```swift
+import SwiftUI
+import Flutter
+
+@main
+struct FlutNFeelApp: App {
+  let flutterEngine = FlutterEngine(name: "flutnfeel_engine")
+  
+  init() {
+    flutterEngine.run()
+    GeneratedPluginRegistrant.register(with: flutterEngine) // provided by FlutNFeel pod
+  }
+  
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .environmentObject(FlutterEngineWrapper(engine: flutterEngine))
+    }
+  }
+}
+
+class FlutterEngineWrapper: ObservableObject {
+  let engine: FlutterEngine
+  
+  init(engine: FlutterEngine) {
+    self.engine = engine
+  }
+}
+
+struct ContentView: View {
+  @EnvironmentObject var flutterEngine: FlutterEngineWrapper
+  @State private var isFlutterPresented = false
+  
+  var body: some View {
+    NavigationView {
+      VStack(spacing: 20) {
+        Text("FlutNFeel Demo")
+          .font(.largeTitle)
+          .fontWeight(.bold)
+        
+        Button("Show Flutter") {
+          isFlutterPresented = true
+        }
+        .font(.title2)
+        .foregroundColor(.white)
+        .padding()
+        .background(Color.blue)
+        .cornerRadius(10)
+      }
+      .navigationTitle("Home")
+    }
+    .fullScreenCover(isPresented: $isFlutterPresented) {
+      FlutterViewControllerWrapper(engine: flutterEngine.engine)
+    }
+  }
+}
+
+struct FlutterViewControllerWrapper: UIViewControllerRepresentable {
+  let engine: FlutterEngine
+  
+  func makeUIViewController(context: Context) -> FlutterViewController {
+    let flutterViewController = FlutterViewController(engine: engine, nibName: nil, bundle: nil)
+    return flutterViewController
+  }
+  
+  func updateUIViewController(_ uiViewController: FlutterViewController, context: Context) {
+    // No updates needed
+  }
+}
+
+#Preview {
+  ContentView()
+    .environmentObject(FlutterEngineWrapper(engine: FlutterEngine()))
 }
 ```
 

--- a/scripts/build_pod.sh
+++ b/scripts/build_pod.sh
@@ -33,7 +33,16 @@ flutter build ios-framework --output=./build/ios-framework --cocoapods ${DEBUG_F
 echo
 echo "Artifacts:"
 ls -la build/ios-framework || true
-ls -la build/ios-framework/Release || true
+if [ -d build/ios-framework ]; then
+  ls -la build/ios-framework
+else
+  echo "Directory build/ios-framework does not exist."
+fi
+if [ -d build/ios-framework/Release ]; then
+  ls -la build/ios-framework/Release
+else
+  echo "Directory build/ios-framework/Release does not exist."
+fi
 
 echo
 echo "Done. Point your host app Podfile to:"

--- a/scripts/build_pod.sh
+++ b/scripts/build_pod.sh
@@ -48,6 +48,5 @@ echo "Done. Point your host app Podfile to:"
 ls -la build/ios-framework/$MODE || true
 
 echo
-echo "Done. Point your host app Podfile to:"
 echo "  pod 'Flutter', :podspec => File.join('<path-to-FlutNFeel>', 'build', 'ios-framework', '$MODE', 'Flutter.podspec')"
 echo "  pod 'FlutNFeel', :path => '<path-to-FlutNFeel>'"

--- a/scripts/build_pod.sh
+++ b/scripts/build_pod.sh
@@ -32,7 +32,6 @@ flutter build ios-framework --output=./build/ios-framework --cocoapods ${DEBUG_F
 
 echo
 echo "Artifacts:"
-ls -la build/ios-framework || true
 if [ -d build/ios-framework ]; then
   ls -la build/ios-framework
 else

--- a/scripts/build_pod.sh
+++ b/scripts/build_pod.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the Flutter iOS frameworks and engine podspec for CocoaPods consumption.
+# Usage: ./scripts/build_pod.sh [release|profile|debug]
+
+MODE=${1:-release}
+case "$MODE" in
+  release)
+    DEBUG_FLAG=--no-debug
+    PROFILE_FLAG=--no-profile
+    ;;
+  profile)
+    DEBUG_FLAG=--no-debug
+    PROFILE_FLAG=--profile
+    ;;
+  debug)
+    DEBUG_FLAG=--debug
+    PROFILE_FLAG=--no-profile
+    ;;
+  *)
+    echo "Unknown mode: $MODE" >&2
+    exit 1
+    ;;
+esac
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT_DIR"
+
+flutter pub get
+flutter build ios-framework --output=./build/ios-framework --cocoapods ${DEBUG_FLAG} ${PROFILE_FLAG}
+
+echo
+echo "Artifacts:"
+ls -la build/ios-framework || true
+ls -la build/ios-framework/Release || true
+
+echo
+echo "Done. Point your host app Podfile to:"
+echo "  pod 'Flutter', :podspec => File.join('<path-to-FlutNFeel>', 'build', 'ios-framework', 'Release', 'Flutter.podspec')"
+echo "  pod 'FlutNFeel', :path => '<path-to-FlutNFeel>'"

--- a/scripts/build_pod.sh
+++ b/scripts/build_pod.sh
@@ -46,5 +46,9 @@ fi
 
 echo
 echo "Done. Point your host app Podfile to:"
-echo "  pod 'Flutter', :podspec => File.join('<path-to-FlutNFeel>', 'build', 'ios-framework', 'Release', 'Flutter.podspec')"
+ls -la build/ios-framework/$MODE || true
+
+echo
+echo "Done. Point your host app Podfile to:"
+echo "  pod 'Flutter', :podspec => File.join('<path-to-FlutNFeel>', 'build', 'ios-framework', '$MODE', 'Flutter.podspec')"
 echo "  pod 'FlutNFeel', :path => '<path-to-FlutNFeel>'"


### PR DESCRIPTION
## Summary

Package this Flutter UI module for iOS consumption via CocoaPods.

## Changes

- **FlutNFeel.podspec** (v0.1.0)
  - Vends  (App + plugins)
  - Exposes  as public headers
  - Depends on Flutter pod (engine)

- **scripts/build_pod.sh**
  - Reproducible builds: release/profile/debug variants
  - Produces Flutter.podspec and .xcframeworks under 

- **Documentation**
  -  and : step-by-step and reference instructions
  - Updated README to link export guides

## How to Test

From repo root:
```bash
./scripts/build_pod.sh release
```

In a sample iOS app Podfile:
```ruby
pod 'Flutter', :podspec => File.join('<path-to-FlutNFeel>', 'build', 'ios-framework', 'Release', 'Flutter.podspec')
pod 'FlutNFeel', :git => 'https://github.com/motojojoe/FlutNFeel.git', :tag => '0.1.0'
```

Then `pod install` and present a `FlutterViewController` using a shared `FlutterEngine` and `GeneratedPluginRegistrant`.

## Risk Assessment

- **Low risk**: New podspec and script are additive; no changes to app logic
- Tagged as v0.1.0 to match podspec version for `:git + :tag` consumption

## Follow-ups

- Consider binary distribution strategy if hosting .xcframeworks externally
- Optional: Add CI automation and sample host iOS app for integration testing